### PR TITLE
chore: optimize sync stream adapters

### DIFF
--- a/src/streams.ts
+++ b/src/streams.ts
@@ -154,7 +154,7 @@ class SyncWritableStreamAdapter
   }
 
   async postRun(): Promise<void> {
-    const slice = this.#buffer.slice(0, this.#bytesWritten)
+    const slice = this.#buffer.subarray(0, this.#bytesWritten)
     await this.#writer.write(slice)
     await this.#writer.close()
   }


### PR DESCRIPTION
Optimizes `SyncReadableStreamAdapter` by tracking the length of chunks while reading instead of a second pass over the chunks and optimizes `SyncWritableStreamAdapter` by buffering writes to the stream.