### PR TITLE
macos: fix local build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 dist
 node_modules
 deps/wasi-sdk-13.0
+*.sha256

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,15 @@ clean:
 	rm -rf ./node_modules/
 	rm -rf ./test/node_modules/
 
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+  WASI_SDK_FILE := wasi-sdk-13.0-macos.tar.gz
+  WASI_SDK_PATH := wasi-sdk-13
+else
+  WASI_SDK_FILE := wasi-sdk-13.0-linux.tar.gz
+  WASI_SDK_PATH := wasi-sdk-13
+endif
+
 WASI_SDK_PATH := ./deps/wasi-sdk-13.0
 WASI_SYSROOT  := $(abspath ${WASI_SDK_PATH}/share/wasi-sysroot)
 
@@ -55,7 +64,8 @@ dist/index.mjs: $(wildcard ./src/**) node_modules dist/memfs.wasm
 
 $(WASI_SDK_PATH):
 	mkdir -p $(@D)
-	curl -sLo wasi-sdk.tar.gz https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-13/wasi-sdk-13.0-linux.tar.gz
-	echo 'aea04267dd864a2f41e21f6cc43591b73dd8901e1ad4e87decf8c4b5905c73cf wasi-sdk.tar.gz' | sha256sum -c
-	tar zxf wasi-sdk.tar.gz --touch -C deps
-	rm wasi-sdk.tar.gz
+	curl -sLo $(WASI_SDK_FILE) https://github.com/WebAssembly/wasi-sdk/releases/download/$(WASI_SDK_PATH)/$(WASI_SDK_FILE)
+	curl -sLo $(WASI_SDK_FILE).sha256 https://github.com/WebAssembly/wasi-sdk/releases/download/$(WASI_SDK_PATH)/$(WASI_SDK_FILE).sha256
+	cat $(WASI_SDK_FILE).sha256 | sha256sum -c
+	tar zxf $(WASI_SDK_FILE) --touch -C deps
+	rm $(WASI_SDK_FILE) $(WASI_SDK_FILE).sha256

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,14 @@
 default: run-tests
 
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+  BINARYEN_FILE := binaryen-version_100-x86_64-macos.tar.gz
+  BINARYEN_PATH := version_100
+else
+  BINARYEN_FILE := binaryen-version_100-x86_64-linux.tar.gz
+  BINARYEN_PATH := version_100
+endif
+
 WASM_OPT   := ../build/binaryen/bin/wasm-opt
 WASI_SDK_PATH := ../deps/wasi-sdk-13.0
 WASI_SYSROOT  := $(abspath ${WASI_SDK_PATH}/share/wasi-sysroot)
@@ -66,10 +75,11 @@ $(BUNDLE): $(wildcard ../dist/**) $(wildcard ./driver/**) $(MEMFS_DST) $(OUTPUT_
 $(WASM_OPT):
 	@$(call color,"downloading binaryen")
 	mkdir -p $(@D)
-	curl -Lo binaryen.tar.gz https://github.com/WebAssembly/binaryen/releases/download/version_100/binaryen-version_100-x86_64-linux.tar.gz
-	echo '9057c8f3f0bbfec47a95985c8f0faad8cc2aa3932e94a7d6b705e245ed140e19  binaryen.tar.gz' | sha256sum -c
-	tar zxvf binaryen.tar.gz --strip-components=1 --touch -C ../build/binaryen
-	rm binaryen.tar.gz
+	curl -sLo $(BINARYEN_FILE) https://github.com/WebAssembly/binaryen/releases/download/$(BINARYEN_PATH)/$(BINARYEN_FILE)
+	curl -sLo $(BINARYEN_FILE).sha256 https://github.com/WebAssembly/binaryen/releases/download/$(BINARYEN_PATH)/$(BINARYEN_FILE).sha256
+	cat $(BINARYEN_FILE).sha256 | sha256sum -c
+	tar zxvf $(BINARYEN_FILE) --strip-components=1 --touch -C ../build/binaryen
+	rm $(BINARYEN_FILE) $(BINARYEN_FILE).sha256
 
 export WASI_CC      := $(abspath ${WASI_SDK_PATH}/bin/clang) -target wasm32-wasi --sysroot=${WASI_SYSROOT}
 export WASI_CFLAGS  := -Oz -flto
@@ -77,5 +87,5 @@ export WASI_LDFLAGS := -flto -Wl,--allow-undefined
 
 $(BENCHMARK_DST)/%.wasm: $(WASI_SDK_PATH) $(WASM_OPT) $(BENCHMARK_SRC)/%.c
 	mkdir -p $(BENCHMARK_DST)
-	$(WASI_CC) $(WASI_CFLAGS) $(WASI_LDFLAGS) subjects/$*.c -o $(BENCHMARK_DST)/$*.wasm 
+	$(WASI_CC) $(WASI_CFLAGS) $(WASI_LDFLAGS) subjects/$*.c -o $(BENCHMARK_DST)/$*.wasm
 	$(WASM_OPT) -g -O --asyncify $(BENCHMARK_DST)/$*.wasm -o $(BENCHMARK_DST)/$*.asyncify.wasm


### PR DESCRIPTION
This PR fixes the local build on MacOS by downloading the right WASI SDK and Binaryen releases.