### PR TITLE
fix: deprecation of actions/upload-artifact@v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         name: Test Report
         path: ./build/test/junit.xml
         reporter: jest-junit
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: github.event.pull_request.head.repo.full_name == github.repository
       with:
         name: cloudflare-workers-wasi.tgz


### PR DESCRIPTION
build job is failed: https://github.com/cloudflare/workers-wasi/actions/runs/10951819557/job/30409488057

migration guide: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md
- [x] no same name artifact
- [x] no overwrite
- [x] no merge
- [x] no hidden files

![image](https://github.com/user-attachments/assets/8c6af410-12db-45b6-88db-1a935c826f54)
