### PR TITLE
Update node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 # install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_17.x  | bash -
+RUN curl -sL https://deb.nodesource.com/setup_22.x  | bash -
 RUN apt-get -qq -y install nodejs
 
 WORKDIR /workers-wasi

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ node_modules: ./package.json ./package-lock.json
 
 dist/index.mjs: $(wildcard ./src/**) node_modules dist/memfs.wasm
 	sed -i 's/^class Asyncify/export class Asyncify/g' ./deps/asyncify/asyncify.mjs
-	$(shell npm bin)/tsc -p ./tsconfig.json
-	$(shell npm bin)/esbuild --bundle ./src/index.ts --outfile=$@ --format=esm --log-level=warning --external:*.wasm
+	$(shell npm root)/.bin/tsc -p ./tsconfig.json
+	$(shell npm root)/.bin/esbuild --bundle ./src/index.ts --outfile=$@ --format=esm --log-level=warning --external:*.wasm
 
 $(WASI_SDK_PATH):
 	mkdir -p $(@D)

--- a/test/Makefile
+++ b/test/Makefile
@@ -47,9 +47,9 @@ $(OUTPUT_DIR)/standalone.mjs: $(BENCHMARK_DST_TESTS) node_modules ./driver/*.ts
 	node benchmark-build.mjs
 
 run-tests: $(BUNDLE) $(OUTPUT_DIR)/wasm-table.ts node_modules $(OUTPUT_DIR)/standalone.mjs
-	$(shell npm bin)/tsc -p ./tsconfig.json
+	$(shell npm root)/.bin/tsc -p ./tsconfig.json
 	JEST_JUNIT_OUTPUT_DIR=$(OUTPUT_DIR) OUTPUT_DIR=$(OUTPUT_DIR) NODE_OPTIONS=--experimental-vm-modules NODE_NO_WARNINGS=1 \
-        $(shell npm bin)/jest --detectOpenHandles -i
+        $(shell npm root)/.bin/jest --detectOpenHandles -i
 
 $(OUTPUT_DIR)/wasm-table.ts: $(WASI_TEST_SUITE_DST_TESTS) $(WASMTIME_DST_TESTS)
 	mkdir -p $(@D)
@@ -61,7 +61,7 @@ $(MEMFS_DST): $(MEMFS_SRC)
 
 $(BUNDLE): $(wildcard ../dist/**) $(wildcard ./driver/**) $(MEMFS_DST) $(OUTPUT_DIR)/wasm-table.ts node_modules
 	mkdir -p $(@D)
-	$(shell npm bin)/esbuild --bundle ./driver/worker.ts --outfile=$@ --format=esm --log-level=warning --external:*.wasm
+	$(shell npm root)/.bin/esbuild --bundle ./driver/worker.ts --outfile=$@ --format=esm --log-level=warning --external:*.wasm
 
 $(WASM_OPT):
 	@$(call color,"downloading binaryen")


### PR DESCRIPTION
There is 60 second waiting during `$ docker build` on GitHub Actions job due to an older version of node.

![image](https://github.com/user-attachments/assets/2a81f3c4-ccb4-4ec9-998c-1974fb6de92e)
