### PR TITLE
fix: "Not a git repository" error of git diff on make ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update -qq && \
 # install nodejs
 RUN curl -sL https://deb.nodesource.com/setup_17.x  | bash -
 RUN apt-get -qq -y install nodejs
+RUN git config --global --add safe.directory /workers-wasi
 
 WORKDIR /workers-wasi
 


### PR DESCRIPTION
`$ git diff` run inside a Docker container was always failing. This seemed to be a problem related to directory ownership, which was resolved by setting safe.directory.

```
root@fc2e2ac9ff53:/workers-wasi# make -j ci
...

Not a git repository
To compare two paths outside a working tree:
usage: git diff [--no-index] <path> <path>
make: *** [Makefile:10: ci] Error 129
root@fc2e2ac9ff53:/workers-wasi# git status
fatal: detected dubious ownership in repository at '/workers-wasi'
To add an exception for this directory, call:

        git config --global --add safe.directory /workers-wasi
```

https://git-scm.com/docs/git-config#Documentation/git-config.txt-safedirectory